### PR TITLE
Use d3r_debug param instead

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -135,17 +135,21 @@ $(document).ready(function() {
                     }
                 }
 
-                var redirect = 'redirect=' + encodeURIComponent(link.pathname);
-
                 $('#debug_bar').on('click', function(e) {
-                    var url = link.protocol + '//' + link.hostname + '/debug/enable?destination=bar&' + redirect;
-                    chrome.tabs.update(tabs[0].id, {url: url});
+                    const debugLink = link;
+                    const linkQueryParams = new URLSearchParams(debugLink.search);
+                    linkQueryParams.set("d3r_debug", "true");
+                    debugLink.search = linkQueryParams.toString();
+                    chrome.tabs.update(tabs[0].id, {url: debugLink.toString()});
                     window.close();
                 });
 
                 $('#debug_off').on('click', function(e) {
-                    var url = link.protocol + '//' + link.hostname + '/debug/disable?' + redirect;
-                    chrome.tabs.update(tabs[0].id, {url: url});
+                    const debugLink = link;
+                    const linkQueryParams = new URLSearchParams(debugLink.search);
+                    linkQueryParams.set("d3r_debug", "false");
+                    debugLink.search = linkQueryParams.toString();
+                    chrome.tabs.update(tabs[0].id, {url: debugLink.toString()});
                     window.close();
                 });
 


### PR DESCRIPTION
The `/debug/enable` endpoint require you to be logged into the CP (obviously with very good reason). However the `d3r_debug` param doesn't on local.

So for personal preference as I always do this locally I've switched to the query param approach.

Bit of a subjective change but still works the same other than the fact it always enables it locally regardless of CP status